### PR TITLE
reference to location of "hub sink" block

### DIFF
--- a/docs/stage2/hello_world_stage2.md
+++ b/docs/stage2/hello_world_stage2.md
@@ -71,7 +71,7 @@ The first step is to create an Event Hub. There is documentation for doing using
 
 After you have completed this, your new Event Hub should be list in the Resource Group you are using. You now need to get the Connection String for it, so the flowgraph can send messages to the Event Hub. Follow [these steps](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string) to get the Connection String and copy it to your clipboard. 
 
-Now return to the GRC window and find the Event Hub Sink block in the flowgraph.
+Now return to the GRC window and find the Event Hub Sink block in the far right side of the flowgraph.
 
 <center><img src="images/event-hub-sink-block.png"/></center>
  


### PR DESCRIPTION
the png display on browser doesn't show the last block on the right. neither does the gnuradio companion screen. I acknowledge this is dependent on display resolution, but i think the extra words will remind someone to keep scrolling to the right to find the block